### PR TITLE
Use `path.join` in more of case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.44.0 ##
+
+Updates:
+
+- Allow all webconfig param to not set with '/' in end or start.
+
+
 ## 0.43.0 ##
 
 Updates:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-atlas #
 
-Version : 0.43
+Version : 0.44
 
 **For an international version of this README.md, [follow this link](https://haeresis.github.com/NodeAtlas/doc/).**
 
@@ -283,7 +283,7 @@ Ci-dessous un exemple de configuration.
 
 ```js
 {
-    "templatesRelativePath": "templates/",
+    "templatesRelativePath": "templates",
     "routes": {
         "/": {
             "template": "index.htm"
@@ -325,7 +325,7 @@ aux adresses :
 - *http://localhost/member-without-extension/* (ne répondra pas si demandée en GET)
 - *http://localhost/error.html* (renvoi du contenu plein texte (sans balise) avec une erreur 404)
 
-*Note : Si* ***templatesRelativePath*** *n'est pas présent dans « webconfig.js », par défaut le dossier des templates est bien* ***templates/***. ***templatesRelativePath*** *est donc utile seulement pour changer le nom/chemin du répertoire.*
+*Note : Si* ***templatesRelativePath*** *n'est pas présent dans « webconfig.js », par défaut le dossier des templates est bien* ***templates***. ***templatesRelativePath*** *est donc utile seulement pour changer le nom/chemin du répertoire.*
 
 
 
@@ -335,7 +335,7 @@ La configuration ci-dessous est équivalente à la configuration de la section j
 
 ```js
 {
-    "templatesRelativePath": "templates/",
+    "templatesRelativePath": "templates",
     "routes": {
         "/": "index.htm",
         "/member.html": {
@@ -380,7 +380,7 @@ Vous pouvez également héberger tout un tas de fichier sur votre site dans un d
 
 ```js
 {
-    "assetsRelativePath": "assets/"
+    "assetsRelativePath": "assets"
     "routes": {
         "/": {
             "template": "index.htm"
@@ -412,7 +412,7 @@ vous aurez accès aux adresses :
 - *http://localhost/javascript/common.js*
 - *http://localhost/media/images/logo.png*
 
-*Note : Si* ***assetsRelativePath*** *n'est pas présent dans « webconfig.js », par défaut le dossier public est bien* ***assets/***. ***assetsRelativePath*** *est donc utile seulement pour changer le nom/chemin du répertoire.*
+*Note : Si* ***assetsRelativePath*** *n'est pas présent dans « webconfig.js », par défaut le dossier public est bien* ***assets***. ***assetsRelativePath*** *est donc utile seulement pour changer le nom/chemin du répertoire.*
 
 
 
@@ -504,7 +504,7 @@ vous aurez accès aux adresses :
 - *http://localhost/*
 - *http://localhost/liste-des-membres/*
 
-*Note : Si* ***componentsRelativePath*** *n'est pas présent dans « webconfig.js », par défaut le dossier des includes est bien* ***components/***. ***componentsRelativePath*** *est donc utile seulement pour changer le nom/chemin de répertoire.*
+*Note : Si* ***componentsRelativePath*** *n'est pas présent dans « webconfig.js », par défaut le dossier des includes est bien* ***components***. ***componentsRelativePath*** *est donc utile seulement pour changer le nom/chemin de répertoire.*
 
 
 
@@ -515,7 +515,7 @@ Il est possible avec le même template et les mêmes includes de générer des p
 ```js
 {
     "commonVariation": "common.json",
-    "variationsRelativePath": "variations/",
+    "variationsRelativePath": "variations",
     "routes": {
         "/": {
             "template": "template.htm",
@@ -626,7 +626,7 @@ vous aurez accès aux adresses :
 - *http://localhost/*
 - *http://localhost/liste-des-membres/*
 
-*Note : Si* ***variationsRelativePath*** *n'est pas présent dans « webconfig.js », par défaut le dossier des variations est bien* ***variations/***. ***variationsRelativePath*** *est donc utile seulement pour changer le nom/chemin de répertoire.*
+*Note : Si* ***variationsRelativePath*** *n'est pas présent dans « webconfig.js », par défaut le dossier des variations est bien* ***variations***. ***variationsRelativePath*** *est donc utile seulement pour changer le nom/chemin de répertoire.*
 
 
 
@@ -639,7 +639,7 @@ Sur le même principe, les variations peuvent être utilisées pour créer la m�
 ```js
 {
     "languageCode": "en-gb",
-    "variationsRelativePath": "languages/",
+    "variationsRelativePath": "languages",
     "routes": {
         "/": {
             "template": "landing.htm",
@@ -658,7 +658,7 @@ Sur le même principe, les variations peuvent être utilisées pour créer la m�
 }
 ```
 
-*Note : Dans cet exemple j'ai décidé de me passer d'un fichier de variation commune, car je n'ai pas précisé de* ***commonVariation***. *J'ai également totalement arbitrairement décidé de renommer mon dossier* ***variations/*** *en* ***languages/***.
+*Note : Dans cet exemple j'ai décidé de me passer d'un fichier de variation commune, car je n'ai pas précisé de* ***commonVariation***. *J'ai également totalement arbitrairement décidé de renommer mon dossier* ***variations*** *en* ***languages***.
 
 avec les fichiers suivants :
 
@@ -838,7 +838,7 @@ vous pourriez avoir les « webconfig.json » suivant :
 ```js
 {
     "httpPort": 81,
-    "urlRelativeSubPath": "/english",
+    "urlRelativeSubPath": "english",
     "languageCode": "en-gb",
     "routes": {
         "/": {
@@ -858,7 +858,7 @@ vous pourriez avoir les « webconfig.json » suivant :
 ```js
 {
     "httpPort": 82,
-    "urlRelativeSubPath": "/francais",
+    "urlRelativeSubPath": "francais",
     "languageCode": "fr-fr",
     "routes": {
         "/": {
@@ -902,7 +902,7 @@ Avec la configuration suivante il est possible de générer des assets HTML du r
 ```js
 {
     "htmlGenerateBeforeResponse": true,
-    "generatesRelativePath": "generates/",
+    "generatesRelativePath": "generates",
     "routes": {
         "/": {
             "template": "index.htm",
@@ -1045,7 +1045,7 @@ Pour le contrôleur maître, utilisez par exemple cette configuration :
 ```js
 {
     "commonController": "common.js",
-    "controllersRelativePath": "controllers/",
+    "controllersRelativePath": "controllers",
     "routes": {
         "/": {
             "template": "index.htm",
@@ -1510,7 +1510,7 @@ exports.changeDom = website.changeDom;
 exports.asynchrone = website.asynchrone; // Utilisé non pas par « NodeAtlas » mais par « common.js » (voir fichier précédent).
 ```
 
-*Note : Si* ***controllersRelativePath*** *n'est pas présent dans « webconfig.js », par défaut le dossier des controlleurs est bien* ***controllers/***. ***controllersRelativePath*** *est donc utile seulement pour changer le nom/chemin du répertoire.*
+*Note : Si* ***controllersRelativePath*** *n'est pas présent dans « webconfig.js », par défaut le dossier des controlleurs est bien* ***controllers***. ***controllersRelativePath*** *est donc utile seulement pour changer le nom/chemin du répertoire.*
 
 
 
@@ -1553,7 +1553,7 @@ Changez alors la configuration en ceci :
     "httpHostname": "127.0.0.1",
     "httpPort": 7777,
     "httpSecure": true,
-    "urlRelativeSubPath": "/sub/folder",
+    "urlRelativeSubPath": "sub/folder",
     "routes": {
         "/": {
             "template": "index.htm"
@@ -3223,7 +3223,7 @@ en urls absolues avec la variable `urlBasePath` comme ci-dessous :
 ```js
 {
     "httpPort": 7777,
-    "urlRelativeSubPath": "/sub/folder",
+    "urlRelativeSubPath": "sub/folder",
     "routes": {
         "/": {
             "template": "index.htm"
@@ -3541,7 +3541,6 @@ Vous rajouterez à cet ensemble de fichiers, un fichier supplémentaire nommé `
                 </rule>
             </rules>
         </rewrite>
-
     </system.webServer>
 </configuration>
 ```

--- a/TLDR.md
+++ b/TLDR.md
@@ -50,7 +50,7 @@ Create a `webconfig.json` file and dependencies files for configured your websit
 	"urlHttp": 80,                          /* Set the frontal port for application on the world wide web (proxy). */
 	"httpSecure": "security/server",        /* Set the directory for find "server.key" and "server.crt" file for HTTPs. */
 	"urlHostname": "www.my-website.com",    /* Set the hostname for the application on the world wide web. */
-    "urlRelativeSubPath": "/example",       /* Set a subdirectory for the application url. i.e.: "https://www.my-website.com/example/". */
+    "urlRelativeSubPath": "example",       /* Set a subdirectory for the application url. i.e.: "https://www.my-website.com/example/". */
 	"languageCode": "en-gb",
     "pageNotFound": "/page-404/",
     "commonVariation": "common.json",

--- a/node-atlas.js
+++ b/node-atlas.js
@@ -1,4 +1,3 @@
-
 /*------------------------------------*\
     $%ABOUT
 \*------------------------------------*/
@@ -21,16 +20,15 @@
  * @requires express
  * @requires express-session
  * @requires extend
+ * @requires forcedomain
  * @requires imagemin
  * @requires less-middleware
  * @requires mkpath
- * @requires forcedomain
  * @requires open
  * @requires traverse-directory
  * @requires uglify-js
  */
-/*jslint node: true */
-
+/* jslint node: true */
 
 
 
@@ -43,7 +41,7 @@
  * ABOUT..........................Informations about NodeAtlas.
  * SUMMARY........................It's me !
  * NODE ATLAS OBJECT..............Creation of Main Object.
- * CONFIGURATION..................Global configuration variables, command tool and webconfig. 
+ * CONFIGURATION..................Global configuration variables, command tool and webconfig.
  * GLOBAL FUNCTIONS...............Neutral functions used more once.
  * NODE MODULES...................Functions used to load Node Modules.
  * WEB SERVER.....................Functions used to run pages on http(s) protocol and use middlewares.
@@ -97,7 +95,7 @@ var NA = {};
         var commander = NA.modules.commander;
 
         commander
-        
+
             /* Version of NodeAtlas currently in use with `--version` option. */
             .version('0.43.3')
 
@@ -106,7 +104,7 @@ var NA = {};
 
             /* Target the directory in which website and NodeAtlas will be running. */
             .option(NA.appLabels.commander.directory.command, NA.appLabels.commander.directory.description, String)
-            
+
             /* Change name of JSON file used as the webconfig file. */
             .option(NA.appLabels.commander.webconfig.command, NA.appLabels.commander.webconfig.description, String)
 
@@ -239,7 +237,8 @@ var NA = {};
      * @memberOf node-atlas~NA
      */
     publics.templateEngineConfiguration = function () {
-        var ejs = NA.modules.ejs;
+        var ejs = NA.modules.ejs,
+            path = NA.modules.path;
 
         /**
          * Container for all variations usable into template engine.
@@ -259,7 +258,7 @@ var NA = {};
          * @memberOf node-atlas~NA.variations
          * @default The `NA.websitePhysicalPath` value with webconfig `componentsRelativePath` after.
          */
-        NA.variations.pathname = NA.websitePhysicalPath + NA.webconfig.componentsRelativePath;
+        NA.variations.pathname = path.join(NA.websitePhysicalPath, NA.webconfig.componentsRelativePath);
 
         /**
          * Same as `NA.variations.pathname` with arbitrary value setted after. This value will be represent current page generated for all page generated with template engine.

--- a/node-atlas.js
+++ b/node-atlas.js
@@ -5,7 +5,7 @@
 /**
  * @fileOverview NodeAtlas allows you to create and manage HTML assets or create multilingual websites/webapps easily with Node.js.
  * @author {@link http://www.lesieur.name/ Bruno Lesieur}
- * @version 0.43.3
+ * @version 0.44.0
  * @license {@link https://github.com/Haeresis/ResumeAtlas/blob/master/LICENSE/ GNU GENERAL PUBLIC LICENSE Version 2}
  * @module node-atlas
  * @requires async
@@ -97,7 +97,7 @@ var NA = {};
         commander
 
             /* Version of NodeAtlas currently in use with `--version` option. */
-            .version('0.43.3')
+            .version('0.44.0')
 
             /* Automaticly run default browser with `--browse` options. If a param is setted, the param is added to the and of url. */
             .option(NA.appLabels.commander.browse.command, NA.appLabels.commander.browse.description, String)
@@ -268,7 +268,7 @@ var NA = {};
          * @memberOf node-atlas~NA.variations
          * @default Arbitrarily setted to "all-component.here".
          */
-        NA.variations.filename = NA.variations.pathname + "all-component.here";
+        NA.variations.filename = path.join(NA.variations.pathname, "all-component.here");
 
         /**
          * Set open and close bracket for use EJS.
@@ -312,9 +312,7 @@ var NA = {};
      * @memberOf node-atlas~NA
      */
     publics.improveWebconfigBase = function () {
-        var commander = NA.modules.commander,
-            path = NA.modules.path,
-            regex = new RegExp(path.sep + path.sep + '?$', 'g');
+        var commander = NA.modules.commander;
 
         /**
          * Contain Webconfig file to JSON format.
@@ -404,11 +402,11 @@ var NA = {};
              * @alias variationsRelativePath
              * @type {string}
              * @memberOf node-atlas~NA.webconfig
-             * @default "variations/".
+             * @default "variations".
              */
-            NA.webconfig.variationsRelativePath = NA.webconfig.variationsRelativePath.replace(regex, '') + path.sep;
+            NA.webconfig.variationsRelativePath = NA.webconfig.variationsRelativePath;
         } else {
-            NA.webconfig.variationsRelativePath = 'variations/';
+            NA.webconfig.variationsRelativePath = 'variations';
         }
 
         if (typeof NA.webconfig.controllersRelativePath !== 'undefined') {
@@ -419,11 +417,11 @@ var NA = {};
              * @alias controllersRelativePath
              * @type {string}
              * @memberOf node-atlas~NA.webconfig
-             * @default "controllers/".
+             * @default "controllers".
              */
-            NA.webconfig.controllersRelativePath = NA.webconfig.controllersRelativePath.replace(regex, '') + path.sep;
+            NA.webconfig.controllersRelativePath = NA.webconfig.controllersRelativePath;
         } else {
-            NA.webconfig.controllersRelativePath = 'controllers/';
+            NA.webconfig.controllersRelativePath = 'controllers';
         }
 
         /* Path to template. */
@@ -435,11 +433,11 @@ var NA = {};
              * @alias templatesRelativePath
              * @type {string}
              * @memberOf node-atlas~NA.webconfig
-             * @default "templates/".
+             * @default "templates".
              */
-            NA.webconfig.templatesRelativePath = NA.webconfig.templatesRelativePath.replace(regex, '') + path.sep;
+            NA.webconfig.templatesRelativePath = NA.webconfig.templatesRelativePath;
         } else {
-            NA.webconfig.templatesRelativePath = 'templates/';
+            NA.webconfig.templatesRelativePath = 'templates';
         }
 
         if (typeof NA.webconfig.componentsRelativePath !== 'undefined') {
@@ -450,11 +448,11 @@ var NA = {};
              * @alias componentsRelativePath
              * @type {string}
              * @memberOf node-atlas~NA.webconfig
-             * @default "components/".
+             * @default "components".
              */
-            NA.webconfig.componentsRelativePath = NA.webconfig.componentsRelativePath.replace(regex, '') + path.sep;
+            NA.webconfig.componentsRelativePath = NA.webconfig.componentsRelativePath;
         } else {
-            NA.webconfig.componentsRelativePath = 'components/';
+            NA.webconfig.componentsRelativePath = 'components';
         }
 
         if (typeof NA.webconfig.assetsRelativePath !== 'undefined') {
@@ -465,11 +463,11 @@ var NA = {};
              * @alias assetsRelativePath
              * @type {string}
              * @memberOf node-atlas~NA.webconfig
-             * @default "assets/".
+             * @default "assets".
              */
-            NA.webconfig.assetsRelativePath = NA.webconfig.assetsRelativePath.replace(regex, '') + path.sep;
+            NA.webconfig.assetsRelativePath = NA.webconfig.assetsRelativePath;
         } else {
-            NA.webconfig.assetsRelativePath = 'assets/';
+            NA.webconfig.assetsRelativePath = 'assets';
         }
 
         if (typeof NA.webconfig.generatesRelativePath !== 'undefined') {
@@ -480,11 +478,11 @@ var NA = {};
              * @alias generatesRelativePath
              * @type {string}
              * @memberOf node-atlas~NA.webconfig
-             * @default "generates/".
+             * @default "generates".
              */
-            NA.webconfig.generatesRelativePath = NA.webconfig.generatesRelativePath.replace(regex, '') + path.sep;
+            NA.webconfig.generatesRelativePath = NA.webconfig.generatesRelativePath;
         } else {
-            NA.webconfig.generatesRelativePath = 'generates/';
+            NA.webconfig.generatesRelativePath = 'generates';
         }
 
         /* Adding path to original url. */
@@ -498,10 +496,10 @@ var NA = {};
              * @memberOf node-atlas~NA.webconfig
              * @default Empty.
              * @example
-             * // If `NA.webconfig.urlRelativeSubPath` is setted to "example/"
+             * // If `NA.webconfig.urlRelativeSubPath` is setted to "example"
              * // Website will run by default to « http://localhost/example/ »
              */     
-            NA.webconfig.urlRelativeSubPath = NA.webconfig.urlRelativeSubPath.replace(/\/$/g, '');
+            NA.webconfig.urlRelativeSubPath = '/' + NA.webconfig.urlRelativeSubPath.replace(/^\//g, "").replace(/\/$/g, "");
         } else {
             NA.webconfig.urlRelativeSubPath = '';
         }
@@ -682,7 +680,7 @@ var NA = {};
         /* Check if file exist */
         fs.stat(physicalPath + fileName, function (error) {
             var data = {
-                pathName: path.normalize(physicalPath + fileName)
+                pathName: path.join(physicalPath, fileName)
             };
 
             if (error && error.code === 'ENOENT') {
@@ -1094,8 +1092,8 @@ var NA = {};
 
         if (commander.browse) { NA.configuration.browse = commander.browse; }
         
-        if (NA.configuration.browse) { open(path.normalize('http://localhost' + ((httpPort !== 80) ? ':' + httpPort : '') + '/' + ((typeof NA.configuration.browse === 'string') ? NA.configuration.browse : ""))); }
-    };
+        if (NA.configuration.browse) { open(path.normalize('http://localhost/' + ((typeof NA.configuration.browse === 'string') ? NA.configuration.browse : ""))); }
+    }; 
 
     /**
      * Start a real NodeAtlas Server.
@@ -1215,7 +1213,7 @@ var NA = {};
 
             if (commander.browse) { NA.configuration.browse = commander.browse; }
 
-            if (NA.configuration.browse) { open(path.normalize(NA.webconfig.urlWithoutFileName + NA.webconfig.urlRelativeSubPath + ((typeof NA.configuration.browse === 'string') ? NA.configuration.browse : ""))); }
+            if (NA.configuration.browse) { open(path.join(NA.webconfig.urlWithoutFileName, NA.webconfig.urlRelativeSubPath, ((typeof NA.configuration.browse === 'string') ? NA.configuration.browse : ""))); }
         }
 
         /**
@@ -1290,7 +1288,7 @@ var NA = {};
                 NA.webconfig.enableLess
             ) {
                 /* Generate Less on the fly during the development phase. */
-                NA.httpServer.use(lessMiddleware(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath, {
+                NA.httpServer.use(lessMiddleware(path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath), {
                     postprocess: {
                         css: function(css, req) {
                             return css + "/*# sourceMappingURL=" + req.url.replace(/\.css$/i, '.css.map') + " */";
@@ -1385,12 +1383,13 @@ var NA = {};
      */ 
     publics.httpServerPublicFiles = function () {
         var express = NA.modules.express,
+            path = NA.modules.path,
             commander = NA.modules.commander;
 
         if (commander.generate) { NA.configuration.generate = commander.generate; }
 
         if (!NA.configuration.generate) {
-            NA.httpServer.use(NA.webconfig.urlRelativeSubPath, express["static"](NA.websitePhysicalPath + NA.webconfig.assetsRelativePath, { maxAge: 86400000 * 30 }));
+            NA.httpServer.use(NA.webconfig.urlRelativeSubPath, express["static"](path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath), { maxAge: 86400000 * 30 }));
         }
     };
 
@@ -1460,7 +1459,8 @@ var NA = {};
      * @param {Object} response - Initial response.
      */ 
     publics.redirect = function (currentRouteParameters, request, response) {
-        var location;
+        var location,
+            path = NA.modules.path;
 
         /* Re-inject param into redirected url if is replaced by regex. */
         if (currentRouteParameters.regExp) {
@@ -1480,7 +1480,7 @@ var NA = {};
 
         /* Set status and new location. */
         response.writeHead(currentRouteParameters.statusCode, {
-            Location: NA.webconfig.urlRelativeSubPath + location
+            Location: path.join(NA.webconfig.urlRelativeSubPath, location)
         });
 
         /* No more data. */
@@ -1497,6 +1497,7 @@ var NA = {};
      */ 
     publics.request = function (path, options) {
         var currentRouteParameters = options[path],
+            pathM = NA.modules.path,
             getSupport = true,
             postSupport = true,
             currentPath = path,
@@ -1750,16 +1751,17 @@ var NA = {};
      */ 
     publics.openVariation = function (variationName, languageCode) {
         var fs = NA.modules.fs,
+            path = NA.modules.path,
             dataError = {},
-            variationsPath,
-            languagePath;
-
-            /* Know if variation must be open language subdirectory in first place or not. */
-            if (languageCode) { languagePath = languageCode + '/'; }
-            if (!languageCode) { languagePath = ''; }
+            variationsPath;
 
             /* Find the correct path for variations. */
-            variationsPath = NA.websitePhysicalPath + NA.webconfig.variationsRelativePath + languagePath + variationName;
+            variationsPath = path.join(
+                NA.websitePhysicalPath, 
+                NA.webconfig.variationsRelativePath, 
+                (languageCode) ? languageCode : '', 
+                (variationName) ? variationName : ''
+            );
 
         if (typeof variationName !== 'undefined') {
             dataError.variationsPath = variationsPath;
@@ -1824,11 +1826,11 @@ var NA = {};
 
         /* Add common injections. */
         if (typeof commonInjection === 'string') {
-            allCssFiles.push(path.normalize(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + commonInjection));
+            allCssFiles.push(path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, commonInjection));
         } else {
             if (commonInjection) {
                 for (i = 0; i < commonInjection.length; i++) {
-                    allCssFiles.push(path.normalize(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + NA.webconfig.injectCss[i]));
+                    allCssFiles.push(path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, NA.webconfig.injectCss[i]));
                 }
             }
         }
@@ -1837,22 +1839,22 @@ var NA = {};
         if (specificInjection) {     
             if (typeof specificInjection === 'string') {
                 for (i = 0; i < allCssFiles.length; i++) {
-                    if (path.normalize(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + specificInjection) === allCssFiles[i]) {
+                    if (path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, specificInjection) === allCssFiles[i]) {
                         inject = false;
                     }
                 }
                 if (inject) {
-                    allCssFiles.push(path.normalize(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + specificInjection));
+                    allCssFiles.push(path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, specificInjection));
                 }
             } else {
                 for (var j = 0; j < specificInjection.length; j++) {
                     for (i = 0; i < allCssFiles.length; i++) {
-                        if (path.normalize(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + specificInjection[j]) === allCssFiles[i]) {
+                        if (path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, specificInjection[j]) === allCssFiles[i]) {
                             inject = false;
                         }
                     }
                     if (inject) {
-                        allCssFiles.push(path.normalize(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + specificInjection[j]));
+                        allCssFiles.push(path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, specificInjection[j]));
                     }
                     inject = true;
                 }
@@ -1947,15 +1949,15 @@ var NA = {};
             async.each(allCssMinified, function (compressedFile, firstCallback) {
 
                 async.map(bundles.stylesheets[compressedFile], function (sourceFile, secondCallback) {
-                    secondCallback(null, fs.readFileSync(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + sourceFile, 'utf-8'));
+                    secondCallback(null, fs.readFileSync(path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, sourceFile), 'utf-8'));
                 }, function(error, results) {
                     for (var i = 0; i < results.length; i++) {
                         output += results[i];
                     }
 
                     output = new cleanCss().minify(output);
-                    fs.writeFileSync(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + compressedFile, output);
-                    data.pathName = path.normalize(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + compressedFile);
+                    fs.writeFileSync(path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, compressedFile), output);
+                    data.pathName = path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, compressedFile);
                     console.log(NA.appLabels.cssGenerate.replace(/%([-a-zA-Z0-9_]+)%/g, function (regex, matches) { return data[matches]; }));
                     output = "";
 
@@ -2028,8 +2030,8 @@ var NA = {};
 
             async.each(allImgMinified, function (compressedFile, firstCallback) {
 
-                var source = NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + compressedFile,
-                    output = NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + optimizations.images[compressedFile];
+                var source = path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, compressedFile),
+                    output = path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, optimizations.images[compressedFile]);
 
                     new imagemin()
                         .src(source)
@@ -2115,14 +2117,14 @@ var NA = {};
             async.each(allJsMinified, function (compressedFile, firstCallback) {
 
                 async.map(bundles.javascript[compressedFile], function (sourceFile, secondCallback) {
-                    secondCallback(null, uglifyJs.minify(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + sourceFile, 'utf-8').code);
+                    secondCallback(null, uglifyJs.minify(path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, sourceFile), 'utf-8').code);
                 }, function(error, results) {
                     for (var i = 0; i < results.length; i++) {
                         output += results[i];
                     }
 
-                    fs.writeFileSync(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + compressedFile, output);
-                    data.pathName = path.normalize(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath + compressedFile);
+                    fs.writeFileSync(path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, compressedFile), output);
+                    data.pathName = path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath, compressedFile);
                     console.log(NA.appLabels.jsGenerate.replace(/%([-a-zA-Z0-9_]+)%/g, function (regex, matches) { return data[matches]; }));
                     output = "";
 
@@ -2154,6 +2156,7 @@ var NA = {};
      */ 
     publics.render = function (path, options, request, response) {
         var ejs = NA.modules.ejs,
+            pathM = NA.modules.path,
             extend = NA.modules.extend,
 
             /**
@@ -2190,7 +2193,7 @@ var NA = {};
         }
 
         /* Generate the server path to the template file. */
-        templatesPath = NA.websitePhysicalPath + NA.webconfig.templatesRelativePath + currentRouteParameters.template;
+        templatesPath = pathM.join(NA.websitePhysicalPath, NA.webconfig.templatesRelativePath, currentRouteParameters.template);
 
         /* Case of `currentRouteParameters.url` replace `path` because `path` is used like a key. */
         if (currentRouteParameters.url) {
@@ -2261,7 +2264,7 @@ var NA = {};
                 NA.openTemplate(currentRouteParameters, templatesPath, function (data) {
 
                     /* Set the file currently in use. */
-                    currentVariation.filename = currentVariation.pathname + currentRouteParameters.template;
+                    currentVariation.filename = pathM.join(currentVariation.pathname, currentRouteParameters.template);
 
                     try {
                         /* Transform ejs data and inject incduded file. */
@@ -2420,7 +2423,7 @@ var NA = {};
              * @example http://localhost:7777/subpath
              * https://www.example.here
              */
-            currentVariation.urlBasePathSlice = NA.webconfig.urlWithoutFileName.replace(/\/$/g, "") + ((NA.webconfig.urlRelativeSubPath !== '') ? '/' + NA.webconfig.urlRelativeSubPath.replace(/^\//g, "").replace(/\/$/g, "") : '');
+            currentVariation.urlBasePathSlice = NA.webconfig.urlWithoutFileName.replace(/\/$/g, "") + NA.webconfig.urlRelativeSubPath;
 
             /**
              * Expose the current URL of page with `NA.webconfig.urlWithoutFileName` and `NA.webconfig.urlRelativeSubPath`.
@@ -2639,7 +2642,12 @@ var NA = {};
      * @param {loadController~callback} callback - Next steps after controller loading.
      */
     publics.loadController = function (controller, callback) {
-        var commonControllerPath = NA.websitePhysicalPath + NA.webconfig.controllersRelativePath + controller,
+        var path = NA.modules.path,
+            commonControllerPath = path.join(
+                NA.websitePhysicalPath, 
+                NA.webconfig.controllersRelativePath, 
+                (controller) ? controller : ''
+            ),
             dataError = {};
 
         /* If a controller is required. Loading of this controller... */
@@ -2699,8 +2707,8 @@ var NA = {};
             path = NA.modules.path,
             traverseDirectory = publics.modules.traverseDirectory,
             data = {},
-            sourcePath = path.normalize(NA.websitePhysicalPath + NA.webconfig.assetsRelativePath),
-            destinationPath = path.normalize(NA.websitePhysicalPath + NA.webconfig.generatesRelativePath),
+            sourcePath = path.join(NA.websitePhysicalPath, NA.webconfig.assetsRelativePath),
+            destinationPath = path.join(NA.websitePhysicalPath, NA.webconfig.generatesRelativePath),
             traverse,
             htmlGenerateEnable = true;
 
@@ -2726,7 +2734,7 @@ var NA = {};
 
             /* Generate all HTML files. */
             if (htmlGenerateEnable) {
-                fs.exists(NA.websitePhysicalPath + NA.webconfig.generatesRelativePath, function (exists) {
+                fs.exists(path.join(NA.websitePhysicalPath, NA.webconfig.generatesRelativePath), function (exists) {
                     if (exists) {
                         for (var currentUrl in NA.webconfig.routes) {
                         	if (NA.webconfig.routes.hasOwnProperty(currentUrl)) {
@@ -2734,7 +2742,7 @@ var NA = {};
                             }
                         }
                     } else {
-                        data.templatePath = path.normalize(NA.websitePhysicalPath + NA.webconfig.generatesRelativePath);
+                        data.templatePath = path.join(NA.websitePhysicalPath, NA.webconfig.generatesRelativePath);
                         console.log(NA.appLabels.templateDirectoryNotExist.replace(/%([-a-zA-Z0-9_]+)%/g, function (regex, matches) { return data[matches]; }));
                     }
                 });
@@ -2839,7 +2847,7 @@ var NA = {};
             cheerio = NA.modules.cheerio,
             mkpath = NA.modules.mkpath,
             path = NA.modules.path,
-            pathToSaveFileComplete = NA.websitePhysicalPath + NA.webconfig.generatesRelativePath + templateRenderName,
+            pathToSaveFileComplete = path.join(NA.websitePhysicalPath, NA.webconfig.generatesRelativePath, templateRenderName),
             pathToSaveFile = path.dirname(pathToSaveFileComplete),
             $ = cheerio.load(data),
             deeper,
@@ -2875,7 +2883,7 @@ var NA = {};
                 /* If source is not a HTML format, keep initial data format. */
                 if (data.trim().match(/<\/html>$/g) === null) { innerHTML = data; }
 
-                dataError.pathName = path.normalize(NA.websitePhysicalPath + NA.webconfig.generatesRelativePath + templateRenderName);
+                dataError.pathName = path.join(NA.websitePhysicalPath, NA.webconfig.generatesRelativePath, templateRenderName);
 
                 /* Write file */
                 fs.writeFile(pathToSaveFileComplete, innerHTML, function (error) {

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "express": "4.9.0",
     "express-session": "1.8.1",
     "extend": "1.3.0",
+    "forcedomain": "0.4.0",
     "imagemin": "3.2.0",
     "less-middleware": "2.0.1",
     "mkpath": "0.1.0",
-    "forcedomain": "0.4.0",
     "open": "0.0.5",
     "traverse-directory": "0.3.0",
     "uglify-js": "2.4.15"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-atlas",
   "preferGlobal": true,
-  "version": "0.43.3",
+  "version": "0.44.0",
   "author": {
     "name": "Bruno Lesieur",
     "email": "bruno.lesieur@gmail.com"


### PR DESCRIPTION
Beaucoup de chemins reconstitué peuvent être écrit de la manière suivante dans les messages d'erreur. « C:\exemple\node-atlas\/components/ ». Cela est dû au fait que mettre bout à bout des morceaux de dossier, en fonction de l'OS et ou de la manière d'écrire ne permet pas d’homogénéiser les chemins. La fonction native `path.join` pouvant s'en charger, elle va être intégrer à divers endroit pour corriger cela. 